### PR TITLE
Fix cover size

### DIFF
--- a/ExportDocs/pdf_templates/template_assets/pdf.css
+++ b/ExportDocs/pdf_templates/template_assets/pdf.css
@@ -102,7 +102,7 @@
     background-repeat: no-repeat;
     background-color:#fff;
     background-size: contain;
-    height: 2500px;
+    height: 1056px;
   }
 
   .cover-page h1 {


### PR DESCRIPTION
This change fixes a bug that happens on Prince version 12 and higher where the cover background image causes it to spill over through the first three pages of the file.